### PR TITLE
Replace automated GitHub Actions with lefthook local gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,7 @@
 name: Test Zscaler Script
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   shellcheck:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ From Zscaler:
 - Idempotence - re-run the script with confidence
 - A dry-run flag to know of changes ahead of time
 
+## Local validation
+
+Install the local Git hooks with:
+
+```shell
+lefthook install
+```
+
+The pre-commit hook runs fast ShellCheck validation for staged shell files. The
+pre-push hook runs the same checks as GitHub Actions: ShellCheck, the Bats test
+suite, help output, and the dry-run path.
+
+Skip a hook only when you have a reason:
+
+```shell
+LEFTHOOK=0 git commit
+LEFTHOOK=0 git push
+git commit --no-verify
+git push --no-verify
+```
+
+GitHub Actions CI is now on-demand instead of running automatically on every
+push or pull request:
+
+```shell
+gh workflow run test.yml
+```
+
 ## A process which worked for me
 
 ```shell

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  parallel: true
+  commands:
+    shellcheck:
+      glob: "*.{sh,bash,bats}"
+      run: scripts/hooks/check-staged-shell.sh --execute {staged_files}
+
+pre-push:
+  commands:
+    local-ci:
+      run: scripts/hooks/run-local-ci.sh --execute

--- a/scripts/hooks/check-staged-shell.sh
+++ b/scripts/hooks/check-staged-shell.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/hooks/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+hook_parse_execute_flag "$@"
+set -- "${HOOK_ARGS[@]}"
+
+if hook_skip_requested; then
+  hook_print_skip_and_exit
+fi
+
+shell_files=()
+advisory_files=()
+for file in "$@"; do
+  [[ -f "${file}" ]] || continue
+  case "${file}" in
+    *.sh)
+      shell_files+=("${file}")
+      ;;
+    *.bash|*.bats)
+      advisory_files+=("${file}")
+      ;;
+  esac
+done
+
+if [[ "${#shell_files[@]}" -eq 0 && "${#advisory_files[@]}" -eq 0 ]]; then
+  hook_ok "shellcheck: no staged shell files"
+  exit 0
+fi
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  hook_fail "shellcheck not found in PATH; install shellcheck or unstage shell files"
+  exit 1
+fi
+
+failed=0
+cd "${HOOKS_REPO_ROOT}"
+
+for file in "${shell_files[@]}"; do
+  if ! shellcheck -x "${file}"; then
+    hook_fail "${file}: fix shellcheck findings before committing"
+    failed=1
+  fi
+done
+
+if [[ "${#advisory_files[@]}" -gt 0 ]]; then
+  if ! shellcheck "${advisory_files[@]}"; then
+    hook_warn "test shellcheck findings are advisory to match GitHub Actions"
+  fi
+fi
+
+if [[ "${failed}" -eq 0 ]]; then
+  hook_ok "shellcheck: ${#shell_files[@]} blocking shell file(s), ${#advisory_files[@]} advisory test file(s)"
+fi
+
+exit "${failed}"

--- a/scripts/hooks/lib.sh
+++ b/scripts/hooks/lib.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034 # Sourced hook scripts consume this shared root.
+HOOKS_REPO_ROOT="$(cd "${HOOKS_DIR}/../.." && pwd)"
+
+hook_parse_execute_flag() {
+  HOOK_ARGS=()
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --execute)
+        shift
+        ;;
+      --)
+        shift
+        HOOK_ARGS+=("$@")
+        break
+        ;;
+      *)
+        HOOK_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
+
+hook_skip_requested() {
+  [[ "${ZSCALER_SKIP_HOOKS:-}" == "1" ]]
+}
+
+hook_print_skip_and_exit() {
+  echo "WARN ZSCALER_SKIP_HOOKS=1; skipping ${0##*/}"
+  exit 0
+}
+
+hook_ok() {
+  echo "OK   $*"
+}
+
+hook_warn() {
+  echo "WARN $*"
+}
+
+hook_fail() {
+  echo "FAIL $*" >&2
+}

--- a/scripts/hooks/run-local-ci.sh
+++ b/scripts/hooks/run-local-ci.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/hooks/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+hook_parse_execute_flag "$@"
+if [[ "${#HOOK_ARGS[@]}" -gt 0 ]]; then
+  hook_fail "unexpected arguments: ${HOOK_ARGS[*]}"
+  exit 1
+fi
+
+if hook_skip_requested; then
+  hook_print_skip_and_exit
+fi
+
+if [[ "${ZSCALER_LOCAL_CI_IN_PROGRESS:-}" == "1" ]]; then
+  hook_warn "ZSCALER_LOCAL_CI_IN_PROGRESS=1; skipping run-local-ci.sh to avoid recursive local CI"
+  exit 0
+fi
+
+cd "${HOOKS_REPO_ROOT}"
+
+cat <<'EOF'
+Zscaler pre-push local CI gate
+
+Running the same checks as .github/workflows/test.yml:
+  shellcheck zscaler-mac.sh
+  find _test -name "*.bash" -o -name "*.bats" | xargs shellcheck || true
+  ./_test/run_tests.sh
+  ./zscaler-mac.sh --help
+  ./zscaler-mac.sh --dry-run --azure-cli --profile
+
+Skip only when you have a reason:
+  LEFTHOOK=0 git push
+  ZSCALER_SKIP_HOOKS=1 git push
+  git push --no-verify
+EOF
+
+export ZSCALER_LOCAL_CI_IN_PROGRESS=1
+failed_gate=""
+
+# shellcheck disable=SC2038 # Keep this command aligned with the existing GitHub Actions workflow.
+if ! shellcheck zscaler-mac.sh; then
+  failed_gate="shellcheck zscaler-mac.sh"
+elif ! find _test -name "*.bash" -o -name "*.bats" | xargs shellcheck; then
+  hook_warn "test shellcheck findings are advisory to match GitHub Actions"
+elif ! ./_test/run_tests.sh; then
+  failed_gate="./_test/run_tests.sh"
+elif ! ./zscaler-mac.sh --help >/dev/null; then
+  failed_gate="./zscaler-mac.sh --help"
+elif ! ./zscaler-mac.sh --dry-run --azure-cli --profile; then
+  failed_gate="./zscaler-mac.sh --dry-run --azure-cli --profile"
+fi
+
+if [[ -n "${failed_gate}" ]]; then
+  hook_fail "pre-push gate failed: ${failed_gate}"
+  exit 1
+fi
+
+hook_ok "pre-push gate passed"


### PR DESCRIPTION
## What changed

- `.github/workflows/test.yml` now uses `workflow_dispatch` only. Its jobs are preserved so the same ShellCheck and Bats checks can still be run on demand.
- Added `lefthook.yml` with a staged-file pre-commit ShellCheck gate and a pre-push local CI gate.
- Added `scripts/hooks/` scripts so the lefthook commands can be run directly without installing hooks in this sandbox.
- Documented hook installation, skip mechanisms, and on-demand GitHub CI in `README.md`.

## Running checks locally

Install hooks after staging this change:

```shell
lefthook install
```

Run the gates directly:

```shell
scripts/hooks/check-staged-shell.sh --execute zscaler-mac.sh _test/helpers/mocks.bash _test/zscaler-mac.bats _test/run_tests.sh scripts/hooks/lib.sh scripts/hooks/check-staged-shell.sh scripts/hooks/run-local-ci.sh
scripts/hooks/run-local-ci.sh --execute
```

Run GitHub CI on demand:

```shell
gh workflow run test.yml
```

Skip hooks only when needed:

```shell
LEFTHOOK=0 git commit
LEFTHOOK=0 git push
git commit --no-verify
git push --no-verify
```

## Deliberately left alone

- No deployment, publishing, or tag-triggered release workflows were present.
- Test-file ShellCheck remains advisory, matching the existing GitHub Actions behavior of `find _test -name "*.bash" -o -name "*.bats" | xargs shellcheck || true`.
- `lefthook install`, `git add`, `git commit`, fetch, push, and PR creation were not run.
